### PR TITLE
Add volume control features to VLC MCP server

### DIFF
--- a/vlc_mcp_player/main.py
+++ b/vlc_mcp_player/main.py
@@ -37,9 +37,7 @@ async def vlc_command(ctx: Context, command, val=None, option=None, input=None):
     await ctx.info(f"Sending VLC command: URL={url}, Params={params}")
 
     try:
-        response = requests.get(
-            url, params=params, auth=("", VLC_HTTP_PASSWORD), timeout=10
-        )
+        response = requests.get(url, params=params, auth=("", VLC_HTTP_PASSWORD), timeout=10)
         await ctx.info(f"VLC response status: {response.status_code}")
         response.raise_for_status()
         return True, ""
@@ -55,9 +53,7 @@ async def vlc_play_video(ctx: Context, video_path, subtitle_id=None):
 
     video_uri = pathlib.Path(video_path).as_uri()
 
-    success, error_message = await vlc_command(
-        ctx, "in_play", input=video_uri, option=option
-    )
+    success, error_message = await vlc_command(ctx, "in_play", input=video_uri, option=option)
     if success:
         time.sleep(4)  # wait for the video to start
         success, error_message = await vlc_command(ctx, "fullscreen", val=1)
@@ -74,12 +70,7 @@ async def get_status(ctx: Context) -> str:
         response.raise_for_status()
         status = response.json()
 
-        filename = (
-            status.get("information", {})
-            .get("category", {})
-            .get("meta", {})
-            .get("filename", "unknown")
-        )
+        filename = status.get("information", {}).get("category", {}).get("meta", {}).get("filename", "unknown")
 
         message = (
             f"Status: {status.get('state', 'unknown')}, time: {status.get('time', 0)}/"
@@ -246,9 +237,7 @@ def get_available_videos(ctx: Context) -> str:
 
 
 @app.tool()
-async def show_video(
-    ctx: Context, video_path: str, subtitle_language_code: str = ""
-) -> str:
+async def show_video(ctx: Context, video_path: str, subtitle_language_code: str = "") -> str:
     """Show the video using the the video path and the subtitle language code. If the subtitle language code is an empty string, the video will play with no subtitle."""
     full_video_path = os.path.join(ROOT_VIDEO_FOLDER, video_path)
     await ctx.info(f"Full video path:\n{full_video_path}")
@@ -266,10 +255,7 @@ async def show_video(
 
         if subtitle_id is None:
             subtitle_str = ", ".join(
-                [
-                    f"{subtitle_info['language']} - {subtitle_info['title']}"
-                    for subtitle_info in subtitle_list
-                ]
+                [f"{subtitle_info['language']} - {subtitle_info['title']}" for subtitle_info in subtitle_list]
             )
             return (
                 f"No matching subtitle with the language code {subtitle_language_code} "

--- a/vlc_mcp_player/main.py
+++ b/vlc_mcp_player/main.py
@@ -37,7 +37,9 @@ async def vlc_command(ctx: Context, command, val=None, option=None, input=None):
     await ctx.info(f"Sending VLC command: URL={url}, Params={params}")
 
     try:
-        response = requests.get(url, params=params, auth=("", VLC_HTTP_PASSWORD), timeout=10)
+        response = requests.get(
+            url, params=params, auth=("", VLC_HTTP_PASSWORD), timeout=10
+        )
         await ctx.info(f"VLC response status: {response.status_code}")
         response.raise_for_status()
         return True, ""
@@ -53,7 +55,9 @@ async def vlc_play_video(ctx: Context, video_path, subtitle_id=None):
 
     video_uri = pathlib.Path(video_path).as_uri()
 
-    success, error_message = await vlc_command(ctx, "in_play", input=video_uri, option=option)
+    success, error_message = await vlc_command(
+        ctx, "in_play", input=video_uri, option=option
+    )
     if success:
         time.sleep(4)  # wait for the video to start
         success, error_message = await vlc_command(ctx, "fullscreen", val=1)
@@ -70,7 +74,12 @@ async def get_status(ctx: Context) -> str:
         response.raise_for_status()
         status = response.json()
 
-        filename = status.get("information", {}).get("category", {}).get("meta", {}).get("filename", "unknown")
+        filename = (
+            status.get("information", {})
+            .get("category", {})
+            .get("meta", {})
+            .get("filename", "unknown")
+        )
 
         message = (
             f"Status: {status.get('state', 'unknown')}, time: {status.get('time', 0)}/"
@@ -115,8 +124,86 @@ async def vlc_control(ctx: Context, action: str) -> str:
     elif action == "fullscreen":
         success, error_message = await vlc_command(ctx, "fullscreen", val=1)
         message = "Fullscreen mode enabled."
-        
+
     return message if success else f"VLC command failed: {error_message}"
+
+
+@app.tool()
+async def set_volume(ctx: Context, volume_level: int) -> str:
+    """Set the volume level of VLC (0-200, where 100 is normal volume).
+
+    Args:
+        volume_level: An integer between 0 and 200 representing the volume percentage
+    """
+    # Validate volume level
+    if not 0 <= volume_level <= 200:
+        return f"Invalid volume level: {volume_level}. Please use a value between 0 and 200."
+
+    # VLC uses values from 0-512, where 256 is 100% volume
+    vlc_volume = int(volume_level * 256 / 100)
+
+    success, error_message = await vlc_command(ctx, "volume", val=vlc_volume)
+
+    if success:
+        return f"Volume set to {volume_level}%."
+    else:
+        return f"Failed to set volume: {error_message}"
+
+
+@app.tool()
+async def get_volume(ctx: Context) -> str:
+    """Get the current volume level of VLC (as a percentage)."""
+    try:
+        status_url = f"http://{VLC_HTTP_HOST}:{VLC_HTTP_PORT}/requests/status.json"
+        await ctx.info(f"Sending VLC command: URL={status_url}")
+        response = requests.get(status_url, auth=("", VLC_HTTP_PASSWORD), timeout=10)
+        response.raise_for_status()
+        status = response.json()
+
+        # VLC volume range is 0-512, where 256 is 100%
+        vlc_volume = status.get("volume", 0)
+        percentage = int(vlc_volume * 100 / 256)
+
+        return f"Current volume: {percentage}%"
+    except requests.RequestException as e:
+        return f"Failed to get volume: {e}"
+
+
+@app.tool()
+async def adjust_volume(ctx: Context, change: int) -> str:
+    """Increase or decrease the volume by a specified percentage.
+
+    Args:
+        change: An integer representing the percentage to change the volume by.
+               Positive values increase volume, negative values decrease it.
+    """
+    try:
+        # First get current volume
+        status_url = f"http://{VLC_HTTP_HOST}:{VLC_HTTP_PORT}/requests/status.json"
+        response = requests.get(status_url, auth=("", VLC_HTTP_PASSWORD), timeout=10)
+        response.raise_for_status()
+        status = response.json()
+
+        # Get current volume and convert to percentage
+        current_vlc_volume = status.get("volume", 0)
+        current_percentage = int(current_vlc_volume * 100 / 256)
+
+        # Calculate new volume percentage
+        new_percentage = current_percentage + change
+        new_percentage = max(0, min(200, new_percentage))  # Clamp to 0-200%
+
+        # Convert back to VLC volume value
+        new_vlc_volume = int(new_percentage * 256 / 100)
+
+        # Set the new volume
+        success, error_message = await vlc_command(ctx, "volume", val=new_vlc_volume)
+
+        if success:
+            return f"Volume adjusted from {current_percentage}% to {new_percentage}%"
+        else:
+            return f"Failed to adjust volume: {error_message}"
+    except requests.RequestException as e:
+        return f"Failed to adjust volume: {e}"
 
 
 def get_available_subtitles(video_path) -> str:
@@ -159,7 +246,9 @@ def get_available_videos(ctx: Context) -> str:
 
 
 @app.tool()
-async def show_video(ctx: Context, video_path: str, subtitle_language_code: str = "") -> str:
+async def show_video(
+    ctx: Context, video_path: str, subtitle_language_code: str = ""
+) -> str:
     """Show the video using the the video path and the subtitle language code. If the subtitle language code is an empty string, the video will play with no subtitle."""
     full_video_path = os.path.join(ROOT_VIDEO_FOLDER, video_path)
     await ctx.info(f"Full video path:\n{full_video_path}")
@@ -177,7 +266,10 @@ async def show_video(ctx: Context, video_path: str, subtitle_language_code: str 
 
         if subtitle_id is None:
             subtitle_str = ", ".join(
-                [f"{subtitle_info['language']} - {subtitle_info['title']}" for subtitle_info in subtitle_list]
+                [
+                    f"{subtitle_info['language']} - {subtitle_info['title']}"
+                    for subtitle_info in subtitle_list
+                ]
             )
             return (
                 f"No matching subtitle with the language code {subtitle_language_code} "


### PR DESCRIPTION
- Add set_volume tool to adjust absolute volume level (0-200%)
- Add get_volume tool to retrieve current volume as percentage
- Add adjust_volume tool to increase/decrease volume relatively
- Implement proper VLC HTTP API integration for volume control
- Convert between percentage (user-friendly) and VLC internal values
- Add validation and error handling for volume operations

These features provide complete volume control capabilities through MCP interface.